### PR TITLE
Use `cross-compilation` in Docker image

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"


### PR DESCRIPTION
Use `cross-compilation` instead of `emulation` in Docker image. Closes #80.