### PR TITLE
Use `libssl-dev:armhf` in pkg-deb for ARMv7

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -35,6 +35,8 @@ jobs:
         if: matrix.target == 'armv7-unknown-linux-gnueabihf'
         run: |
           sudo dpkg --add-architecture armhf
+          sudo sed -i "s/\(\deb \)\(http.*\)/\1[arch=amd64] \2/g" /etc/apt/sources.list
+          echo "deb [arch=armhf] http://ports.ubuntu.com/ trusty main universe" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get install -y libssl-dev:armhf gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf lintian
 

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install libs for ARMv7
         if: matrix.target == 'armv7-unknown-linux-gnueabihf'
         run: |
-          sudo dpkg dpkg --add-architecture armhf
+          sudo dpkg --add-architecture armhf
           sudo apt-get update
           sudo apt-get install -y libssl-dev:armhf gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf lintian
 

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -35,10 +35,15 @@ jobs:
         if: matrix.target == 'armv7-unknown-linux-gnueabihf'
         run: |
           sudo dpkg --add-architecture armhf
-          sudo sed -i "s/\(\deb \)\(http.*\)/\1[arch=amd64] \2/g" /etc/apt/sources.list
-          echo "deb [arch=armhf] http://ports.ubuntu.com/ trusty main universe" | sudo tee -a /etc/apt/sources.list
+          sudo sed 's/deb http/deb \[arch=amd64,i386\] http/' -i /etc/apt/sources.list
+          tee -a /etc/apt/sources.list > /dev/null <<EOF
+          deb [arch=armhf] http://ports.ubuntu.com/ focal main universe restricted multiverse
+          deb [arch=armhf] http://ports.ubuntu.com/ focal-updates main universe restricted multiverse
+          deb [arch=armhf] http://ports.ubuntu.com/ focal-security main universe restricted multiverse
+          EOF
+
           sudo apt-get update
-          sudo apt-get install -y libssl-dev:armhf gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf lintian
+          sudo apt-get install -y libssl-dev:armhf gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture armhf
           sudo sed 's/deb http/deb \[arch=amd64,i386\] http/' -i /etc/apt/sources.list
-          tee -a /etc/apt/sources.list > /dev/null <<EOF
+          sudo tee -a /etc/apt/sources.list > /dev/null <<EOF
           deb [arch=armhf] http://ports.ubuntu.com/ focal main universe restricted multiverse
           deb [arch=armhf] http://ports.ubuntu.com/ focal-updates main universe restricted multiverse
           deb [arch=armhf] http://ports.ubuntu.com/ focal-security main universe restricted multiverse

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -17,6 +17,8 @@ jobs:
     name: Deb package
     env:
       CARGO_DEB_VER: 1.38.0
+      DEBIAN_FRONTEND: noninteractive
+      PKG_CONFIG_ALLOW_CROSS: 1
     strategy:
       matrix:
         target:
@@ -24,47 +26,17 @@ jobs:
           - "armv7-unknown-linux-gnueabihf"
     runs-on: ubuntu-20.04
     steps:
-      - name: Install libs on x86-64
-        if: startsWith(matrix.target, 'arm') != true
-        env:
-          DEBIAN_FRONTEND: noninteractive
+      - name: Install common libs
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake pkg-config libssl-dev lintian
+          sudo apt-get install pkg-config libssl-dev lintian
 
-      - name: Install libs on ARM
-        if: startsWith(matrix.target, 'arm')
-        env:
-          DEBIAN_FRONTEND: noninteractive
+      - name: Install libs for ARMv7
+        if: matrix.target == 'armv7-unknown-linux-gnueabihf'
         run: |
+          sudo dpkg dpkg --add-architecture armhf
           sudo apt-get update
-          sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf lintian
-
-      - name: Cache OpenSSL on ARM
-        if: startsWith(matrix.target, 'arm')
-        id: cache-openssl-arm
-        uses: actions/cache@v3
-        with:
-          path: /tmp/openssl-1.1.1m/
-          key: openssl-1.1.1m-${{ matrix.target }}
-
-      - name: Install OpenSSL on ARM
-        if: startsWith(matrix.target, 'arm') && steps.cache-openssl-arm.outputs.cache-hit != 'true'
-        run: |
-          cd /tmp
-          wget https://www.openssl.org/source/openssl-1.1.1m.tar.gz
-          echo "f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96  openssl-1.1.1m.tar.gz" | sha256sum -c
-          tar xzf openssl-1.1.1m.tar.gz
-          export MACHINE=armv7
-          export ARCH=arm
-          export CC=arm-linux-gnueabihf-gcc
-          cd openssl-1.1.1m && ./config shared && make && cd -
-
-      - name: Set OpenSSL env vars on ARM
-        if: startsWith(matrix.target, 'arm')
-        run: |
-          echo "OPENSSL_LIB_DIR=/tmp/openssl-1.1.1m/" >> $GITHUB_ENV
-          echo "OPENSSL_INCLUDE_DIR=/tmp/openssl-1.1.1m/include" >> $GITHUB_ENV
+          sudo apt-get install -y libssl-dev:armhf gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf lintian
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Use `libssl-dev:armhf` lib in pkg-deb workflow for ARMv7 instead of building `openssl` from source.